### PR TITLE
Uni 55658 create standalone demo of second hot reload crash

### DIFF
--- a/hotReloadCrashRepro/App.config
+++ b/hotReloadCrashRepro/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/hotReloadCrashRepro/Program.cs
+++ b/hotReloadCrashRepro/Program.cs
@@ -19,13 +19,14 @@ namespace hotReloadCrashRepro
         static void Main(string[] args)
         {
             // Defaults is missing args
-            string pathToTheAssembly = @"D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\theAssembly.cs";
+            string pathToTheAssembly = @"D:\projects\pythonnet\hotReloadCrashRepro\theAssembly.cs";
             if (args.Length > 0)
             {
                 pathToTheAssembly = args[0];
             }
 
             // The exception is thrown on the second call to Py_Finalize
+            Assembly theCompiledAssembly = null;
             for(int i = 0; i < 2; ++i) {
                 // Create the domain
                 System.Console.WriteLine(string.Format("[Program.Main] ===Pass #{0}===",i));
@@ -38,7 +39,7 @@ namespace hotReloadCrashRepro
                     System.Console.WriteLine("[Program.Main] Building the assembly");
 
                     // The assembly is compiled as a dll in the same directory as the Program executable
-                    var theCompiledAssembly = BuildAssembly(pathToTheAssembly, "TheCompiledAssembly.dll");
+                    theCompiledAssembly = BuildAssembly(pathToTheAssembly, "TheCompiledAssembly.dll");
                 }
               
                 // Create a Proxy object in the new domain, where we want the
@@ -49,7 +50,7 @@ namespace hotReloadCrashRepro
                     type.FullName);
 
                 // From now on use the Proxy to call into the new assembly
-                theProxy.InitAssembly(string.Format(@"D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\bin\x64\Debug\TheCompiledAssembly.dll",i));
+                theProxy.InitAssembly(theCompiledAssembly.Location);
                 theProxy.RunPython();
 
                 System.Console.WriteLine("[Program.Main] Before Domain Unload");

--- a/hotReloadCrashRepro/Program.cs
+++ b/hotReloadCrashRepro/Program.cs
@@ -1,0 +1,120 @@
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace hotReloadCrashRepro
+{
+    class Program
+    {
+        /// <summary>
+        /// Args goes as follows:
+        ///     0: The full path to theAssembly.cs 
+        /// </summary>
+        /// <param name="args"></param>
+        static void Main(string[] args)
+        {
+            // Defaults is missing args
+            string pathToTheAssembly = @"D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\theAssembly.cs";
+            if (args.Length > 0)
+            {
+                pathToTheAssembly = args[0];
+            }
+
+            // The exception is thrown on the second call to Py_Finalize
+            for(int i = 0; i < 2; ++i) {
+                // Create the domain
+                System.Console.WriteLine(string.Format("[Program.Main] ===Pass #{0}===",i));
+                System.Console.WriteLine(string.Format("[Program.Main] Creating the domain \"My Domain {0}\"",i));
+                var domain = AppDomain.CreateDomain(string.Format("My Domain {0}",i));
+
+                // Build the assembly only once (we reuse the same assembly)
+                if (i == 0)
+                {
+                    System.Console.WriteLine("[Program.Main] Building the assembly");
+
+                    // The assembly is compiled as a dll in the same directory as the Program executable
+                    var theCompiledAssembly = BuildAssembly(pathToTheAssembly, "TheCompiledAssembly.dll");
+                }
+              
+                // Create a Proxy object in the new domain, where we want the
+                // assembly (and Python .NET) to reside
+                Type type = typeof(Proxy);
+                var theProxy = (Proxy)domain.CreateInstanceAndUnwrap(
+                    type.Assembly.FullName,
+                    type.FullName);
+
+                // From now on use the Proxy to call into the new assembly
+                theProxy.InitAssembly(string.Format(@"D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\bin\x64\Debug\TheCompiledAssembly.dll",i));
+                theProxy.RunPython();
+
+                System.Console.WriteLine("[Program.Main] Before Domain Unload");
+                AppDomain.Unload(domain);
+                System.Console.WriteLine("[Program.Main] After Domain Unload");
+
+                // Validate that the assembly does not exist anymore
+                try
+                {
+                    System.Console.WriteLine(string.Format("[Program.Main] The Proxy object is valid ({0}). Unexpected domain unload behavior",theProxy));
+                }
+                catch (Exception)
+                {
+                    System.Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete.");
+                }
+            }
+        }
+
+        public class Proxy : MarshalByRefObject
+        {
+            static Assembly theAssembly = null;
+
+            public void InitAssembly(string assemblyPath)
+            {
+                System.Console.WriteLine(string.Format("[Proxy       ] In InitAssembly"));
+
+                theAssembly = Assembly.LoadFile(assemblyPath);
+                var pythonrunner = theAssembly.GetType("PythonRunner");
+                var initMethod = pythonrunner.GetMethod("Init");
+                initMethod.Invoke(null, new object[] {});
+            }
+            public void RunPython()
+            {
+                System.Console.WriteLine(string.Format("[Proxy       ] In RunPython"));
+
+                // Call into the new assembly. Will execute Python code
+                var pythonrunner = theAssembly.GetType("PythonRunner");
+                var runPythonMethod = pythonrunner.GetMethod("RunPython");
+                runPythonMethod.Invoke(null, new object[] { });
+            }
+        }
+
+        static System.Reflection.Assembly BuildAssembly(string pathToTheAssembly, string outputAssemblyName)
+        {   
+            var provider = CodeDomProvider.CreateProvider("CSharp");
+            var compilerparams = new CompilerParameters(new string [] {"Python.Runtime.dll"});
+
+            compilerparams.GenerateExecutable = false;
+            compilerparams.GenerateInMemory = false;
+            compilerparams.IncludeDebugInformation = true;
+            compilerparams.OutputAssembly = outputAssemblyName;
+
+            var results = 
+                provider.CompileAssemblyFromFile(compilerparams, pathToTheAssembly);
+            if (results.Errors.HasErrors) {   
+                StringBuilder errors = new StringBuilder("Compiler Errors :\r\n");
+                foreach (CompilerError error in results.Errors )
+                {   
+                    errors.AppendFormat("Line {0},{1}\t: {2}\n", 
+                            error.Line, error.Column, error.ErrorText);
+                }
+                throw new Exception(errors.ToString());
+            } else {   
+                return results.CompiledAssembly;
+            }
+        }
+    }
+}

--- a/hotReloadCrashRepro/Properties/AssemblyInfo.cs
+++ b/hotReloadCrashRepro/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("hotReloadCrashRepro")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("HP Inc.")]
+[assembly: AssemblyProduct("hotReloadCrashRepro")]
+[assembly: AssemblyCopyright("Copyright © HP Inc. 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("22642faa-c1aa-403e-97f7-6503790b6fe5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/hotReloadCrashRepro/README.txt
+++ b/hotReloadCrashRepro/README.txt
@@ -1,0 +1,42 @@
+This project will reproduce the Python exception on second domain unload.
+Make sure you use a version of Python .NET that calls PythonEngine.Shutdown() on DomainReload (starting with commit ###################)
+
+How to repro:
+
+1. Open hotReloadCrashRepro.csproj in Visual Studio 2017
+2. Compile
+3. Copy Python.Runtime.dll in the directory where hotReloadCrashRepro.exe is located
+4. Run "hotReloadCrashRepro.exe full_path_to_theAssembly.cs
+    e.g. hotReloadCrashRepro.exe "D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\theAssembly.cs"
+    
+The expected output is:    
+
+[Program.Main] ===Pass #0===
+[Program.Main] Creating the domain "My Domain 0"
+[Program.Main] Building the assembly
+[Proxy       ] In InitAssembly
+[theAssembly ] PythonRunner.Init current domain = My Domain 0
+[Proxy       ] In RunPython
+[theAssembly ] In PythonRunner.RunPython
+[Python      ] Done
+[Program.Main] Before Domain Unload
+[theAssembly ] In OnDomainUnload current domain = My Domain 0
+[Program.Main] After Domain Unload
+[Program.Main] The Proxy object is not valid anymore, domain unload complete.
+[Program.Main] ===Pass #1===
+[Program.Main] Creating the domain "My Domain 1"
+[Proxy       ] In InitAssembly
+[theAssembly ] PythonRunner.Init current domain = My Domain 1
+[Proxy       ] In RunPython
+[theAssembly ] In PythonRunner.RunPython
+[Python      ] Done
+[Program.Main] Before Domain Unload
+[theAssembly ] In OnDomainUnload current domain = My Domain 1
+
+Unhandled Exception: System.AppDomainUnloadedException: Attempted to access an unloaded AppDomain.
+   at Python.Runtime.Runtime.Py_Finalize()
+   at Python.Runtime.Runtime.Shutdown()
+   at Python.Runtime.PythonEngine.Shutdown()
+   at Python.Runtime.PythonEngine.OnDomainUnload(Object sender, EventArgs e)
+[Program.Main] After Domain Unload
+[Program.Main] The Proxy object is not valid anymore, domain unload complete.

--- a/hotReloadCrashRepro/README.txt
+++ b/hotReloadCrashRepro/README.txt
@@ -4,8 +4,8 @@ Make sure you use a version of Python .NET that calls PythonEngine.Shutdown() on
 How to repro:
 
 1. Open hotReloadCrashRepro.csproj in Visual Studio 2017
-2. Compile
-3. Copy Python.Runtime.dll in the directory where hotReloadCrashRepro.exe is located
+2. Compile using the same platform as Python.Runtime.dll (e.g. x64)
+3. Copy Python.Runtime.dll in the directory where hotReloadCrashRepro.exe is located (e.g. bin\x64\Debug)
 4. Run "hotReloadCrashRepro.exe full_path_to_theAssembly.cs
     e.g. hotReloadCrashRepro.exe "D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\theAssembly.cs"
     

--- a/hotReloadCrashRepro/README.txt
+++ b/hotReloadCrashRepro/README.txt
@@ -7,7 +7,7 @@ How to repro:
 2. Compile using the same platform as Python.Runtime.dll (e.g. x64)
 3. Copy Python.Runtime.dll in the directory where hotReloadCrashRepro.exe is located (e.g. bin\x64\Debug)
 4. Run "hotReloadCrashRepro.exe full_path_to_theAssembly.cs
-    e.g. hotReloadCrashRepro.exe "D:\projects\pythonnet\hotReloadCrashRepro\hotReloadCrashRepro\theAssembly.cs"
+    e.g. hotReloadCrashRepro.exe "D:\projects\pythonnet\hotReloadCrashRepro\theAssembly.cs"
     
 The expected output is:    
 

--- a/hotReloadCrashRepro/hotReloadCrashRepro.csproj
+++ b/hotReloadCrashRepro/hotReloadCrashRepro.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{22642FAA-C1AA-403E-97F7-6503790B6FE5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>hotReloadCrashRepro</RootNamespace>
+    <AssemblyName>hotReloadCrashRepro</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/hotReloadCrashRepro/theAssembly.cs
+++ b/hotReloadCrashRepro/theAssembly.cs
@@ -1,0 +1,44 @@
+using System;
+using Python.Runtime;
+using System.Reflection;
+
+public class DummyClass
+{
+    static public DummyClass instance = new DummyClass();
+    public static DummyClass DummyMethod()
+    {
+        return instance;
+    }
+}
+
+class PythonRunner
+{
+    static public void Init()
+    {
+        System.Console.WriteLine(string.Format("[theAssembly ] PythonRunner.Init current domain = {0}",AppDomain.CurrentDomain.FriendlyName));
+
+        // Register to domain unload
+        AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+    }
+
+    private static void OnDomainUnload(object sender, EventArgs e)
+    {
+        System.Console.WriteLine(string.Format("[theAssembly ] In OnDomainUnload current domain = {0}",AppDomain.CurrentDomain.FriendlyName));
+    }
+
+    public static void RunPython() {
+        System.Console.WriteLine("[theAssembly ] In PythonRunner.RunPython");
+        using (Py.GIL()) {
+            try {
+                var pyScript = 
+                    "import clr\n" +
+                    "clr.AddReference('System') \n" +
+                    "print('[Python      ] Done')\n";
+
+                PythonEngine.Exec(pyScript);
+            } catch(Exception e) {
+                System.Console.WriteLine(string.Format("Caught exception: {0}",e));
+            }   
+        }   
+    }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This adds a standalone application that reproduce the thrown exception on second domain unload (System.AppDomainUnloadedException: Attempted to access an unloaded AppDomain)

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
