### PR TITLE
uni-56832: don't register tp_traverse ; seems to avoid the crash

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -248,24 +248,6 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// Default implementations for required Python GC support.
-        /// </summary>
-        public static int tp_traverse(IntPtr ob, IntPtr func, IntPtr args)
-        {
-            return 0;
-        }
-
-        public static int tp_clear(IntPtr ob)
-        {
-            return 0;
-        }
-
-        public static int tp_is_gc(IntPtr type)
-        {
-            return 1;
-        }
-
-        /// <summary>
         /// Standard dealloc implementation for instances of reflected types.
         /// </summary>
         public static void tp_dealloc(IntPtr ob)

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -82,27 +82,6 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// Required Python GC support.
-        /// </summary>
-        public static int tp_traverse(IntPtr ob, IntPtr func, IntPtr args)
-        {
-            return 0;
-        }
-
-
-        public static int tp_clear(IntPtr ob)
-        {
-            return 0;
-        }
-
-
-        public static int tp_is_gc(IntPtr type)
-        {
-            return 1;
-        }
-
-
-        /// <summary>
         /// Default dealloc implementation.
         /// </summary>
         public static void tp_dealloc(IntPtr ob)


### PR DESCRIPTION
There's a crash if we have a domain reload that wipes out the pythonnet assembly:
1. Some objects get leaked. (That's a bug in its own right.)
2. Leaked objects are on the gc list of garbage, even after a Py_Finalize (That's also a bug in its own right.)
3. Objects on the gc list get their tp_traverse function called during a gc collection
4. tp_traverse is a C# method
5. But we did a domain reload, so the C# method is gone... we're calling into garbage!

Solution: "if it hurts, don't do that." Just don't define tp_traverse, which
anyway is just the default implementation in both cases where it was defined.
(Also, two other related functions, also just default implementations.)

If we end up actually defining tp_traverse to do something we will have to
solve this for real.

Would be nice to limit the leaks also, and to improve the Py_Finalize/Py_Initialize loop.