### PR TITLE
Uni 56832 another crash fix attempt

### DIFF
--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{097B4AC0-74E9-4C58-BCF8-C69746EC8271}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>Python.Runtime</AssemblyName>
@@ -22,35 +22,35 @@
   </PropertyGroup>
   <!--We can relax binding to platform because code references no any platform dependent assemblies-->
   <!--This will allows to use any build of this assebly as a compile ref assebly-->
-  <!--<PropertyGroup Condition=" '$(Platform)' == 'x86'">
+  <PropertyGroup Condition=" '$(Platform)' == 'x86'">
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'x64'">
     <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>-->
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">MONO_OSX;PYTHON2;PYTHON27;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <DefineConstants>PYTHON2;PYTHON27;UCS2</DefineConstants>
+    <!--<DefineConstants>PYTHON2;PYTHON27;UCS2</DefineConstants>-->
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">MONO_OSX;PYTHON3;PYTHON36;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">MONO_OSX;PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">MONO_OSX;PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
@@ -170,6 +170,12 @@
   <PropertyGroup>
     <TargetAssembly>$(TargetPath)</TargetAssembly>
     <TargetAssemblyPdb>$(TargetDir)$(TargetName).pdb</TargetAssemblyPdb>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseMono|AnyCPU' ">
+    <DebugType></DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseMonoPY3|AnyCPU' ">
+    <DebugType></DebugType>
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -476,23 +476,6 @@ namespace Python.Runtime
             Exceptions.Shutdown();
             ImportHook.Shutdown();
             Py_Finalize();
-
-            // Now unload the Python library from memory and load it again, providing a
-            // fresh interpreter. This prevents a crash (exception) on second domain reload
-            // https://stackoverflow.com/questions/2445536/unload-a-dll-loaded-using-dllimport
-            if (_PythonDll != "__Internal")
-            {
-                IntPtr dllLocal = NativeMethods.LoadLibrary(_PythonDll);
-
-                // Twice: a first one for the call to LoadLibrary above,
-                //        a second one for the original call to LoadLibrary (should result in unloading the Python library from memory)
-                NativeMethods.FreeLibrary(dllLocal);
-                NativeMethods.FreeLibrary(dllLocal);
-
-                // Here the Python library is supposed to be unloaded.
-                // Load it again in order to get a fresh interpreter
-                NativeMethods.LoadLibrary(_PythonDll);
-            }
         }
 
         // called *without* the GIL acquired by clr._AtExit


### PR DESCRIPTION
On a domain reload, some objects are leaked. When we reinitialize python, those leaked objects are still being tracked by gc. This means their types' tp_traverse, tp_clear, and tp_is_gc slots can get invoked. But since those are implemented in C#, and we unloaded the domain, those slots are pointing to garbage.

Our previous attempt was to unload the cpython library itself and reload it. This works on Windows, but does not work on linux and osx: any native modules that have been loaded depend on cpython, so those operating systems refuse to unload cpython.

This fix instead makes the slots point to functions that are still valid after reloading, but that have no side effects and return the same values (0 for tp_traverse and tp_clear; non-zero for tp_is_gc).

The function that returns zero is PyAST_Check. That means there's a latent bug if someone were to use C# to define a subtype of ast.AST (the python abstract syntax tree). We'd have to document that.

Very minor change embedded in this change: switch from Hashtable to HashSet<string> for cleaner code (and perhaps some speedup).

TODO:
- update authors and changelog
- update hotReloadCrash and put it in the EmbeddingTests
