### PR TITLE
Uni 63112 hotreload crash test

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@
 
 -   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))
+-   Benoît Hudson ([@benoithudson](https://github.com/benoithudson))
 -   Bradley Friedman ([@leith-bartrich](https://github.com/leith-bartrich))
 -   Callum Noble ([@callumnoble](https://github.com/callumnoble))
 -   Christian Heimes ([@tiran](https://github.com/tiran))
@@ -22,6 +23,7 @@
 -   Daniel Fernandez ([@fdanny](https://github.com/fdanny))
 -   Daniel Santana ([@dgsantana](https://github.com/dgsantana))
 -   Dave Hirschfeld ([@dhirschfeld](https://github.com/dhirschfeld))
+-   David Lassonde ([@lassond](https://github.com/lassond))
 -   David Lechner ([@dlech](https://github.com/dlech))
 -   Dmitriy Se ([@dmitriyse](https://github.com/dmitriyse))
 -   He-chien Tsai ([@t3476](https://github.com/t3476))
@@ -39,6 +41,7 @@
 -   Sam Winstanley ([@swinstanley](https://github.com/swinstanley))
 -   Sean Freitag ([@cowboygneox](https://github.com/cowboygneox))
 -   Serge Weinstock ([@sweinst](https://github.com/sweinst))
+-   Viktoria Kovescses ([@vkovec](https://github.com/vkovec))
 -   Ville M. Vainio ([@vivainio](https://github.com/vivainio))
 -   Virgil Dupras ([@hsoft](https://github.com/hsoft))
 -   Wenguang Yang ([@yagweb](https://github.com/yagweb))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Fixed
 
 -   Fixed Visual Studio 2017 compat ([#434][i434]) for setup.py
+-   Fixed crashes when integrating pythonnet in Unity3d ([#714][i714]),
+    related to unloading the Application Domain
 -   Fixed crash on exit of the Python interpreter if a python class
     derived from a .NET class has a `__namespace__` or `__assembly__`
     attribute ([#481][i481])

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -104,6 +104,7 @@
     <Compile Include="TestPyWith.cs" />
     <Compile Include="TestRuntime.cs" />
     <Compile Include="TestPyScope.cs" />
+    <Compile Include="TestTypeManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\runtime\Python.Runtime.csproj">

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -86,6 +86,7 @@
     <Compile Include="pyrunstring.cs" />
     <Compile Include="TestConverter.cs" />
     <Compile Include="TestCustomMarshal.cs" />
+    <Compile Include="TestDomainReload.cs" />
     <Compile Include="TestExample.cs" />
     <Compile Include="TestPyAnsiString.cs" />
     <Compile Include="TestPyFloat.cs" />

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -40,7 +40,6 @@ namespace Python.EmbeddingTest
         /// a hot reload).
         /// </summary>
         [Test]
-        [Ignore("Test crashes")]
         public static void DomainReloadAndGC()
         {
             // We're set up to run in the directory that includes the bin directory.

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -65,6 +65,8 @@ namespace Python.EmbeddingTest
         //
         // What matters in the python code is gc.collect and clr.AddReference.
         //
+        // Note that the language version is 2.0, so no $"foo{bar}" syntax.
+        //
         const string TestCode = @"
             using Python.Runtime;
             using System;
@@ -72,24 +74,25 @@ namespace Python.EmbeddingTest
                 public static void RunPython() {
                     AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
                     string name = AppDomain.CurrentDomain.FriendlyName;
-                    Console.WriteLine($""[{name} in .NET] In PythonRunner.RunPython"");
+                    Console.WriteLine(string.Format(""[{0} in .NET] In PythonRunner.RunPython"", name));
                     using (Py.GIL()) {
                         try {
-                            var pyScript = ""import clr\n""
-                                + $""print('[{name} in python] imported clr')\n""
+                            var pyScript = string.Format(""import clr\n""
+                                + ""print('[{0} in python] imported clr')\n""
                                 + ""clr.AddReference('System')\n""
-                                + $""print('[{name} in python] allocated a clr object')\n""
+                                + ""print('[{0} in python] allocated a clr object')\n""
                                 + ""import gc\n""
                                 + ""gc.collect()\n""
-                                + $""print('[{name} in python] collected garbage')\n"";
+                                + ""print('[{0} in python] collected garbage')\n"",
+                                name);
                             PythonEngine.Exec(pyScript);
                         } catch(Exception e) {
-                            Console.WriteLine($""[{name} in .NET] Caught exception: {e}"");
+                            Console.WriteLine(string.Format(""[{0} in .NET] Caught exception: {1}"", name, e));
                         }
                     }
                 }
                 static void OnDomainUnload(object sender, EventArgs e) {
-                    System.Console.WriteLine(string.Format($""[{AppDomain.CurrentDomain.FriendlyName} in .NET] unloading""));
+                    System.Console.WriteLine(string.Format(""[{0} in .NET] unloading"", AppDomain.CurrentDomain.FriendlyName));
                 }
             }";
 
@@ -139,7 +142,7 @@ namespace Python.EmbeddingTest
 
             public void InitAssembly(string assemblyPath)
             {
-                theAssembly = Assembly.LoadFile(assemblyPath);
+                theAssembly = Assembly.LoadFile(System.IO.Path.GetFullPath(assemblyPath));
             }
 
             public void RunPython()

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -1,0 +1,224 @@
+using System;
+using System.CodeDom.Compiler;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Python.EmbeddingTest
+{
+    class TestDomainReload
+    {
+        /// <summary>
+        /// Test that the python runtime can survive a C# domain reload without crashing.
+        ///
+        /// At the time this test was written, there was a very annoying
+        /// seemingly random crash bug when integrating pythonnet into Unity.
+        ///
+        /// The repro steps we that David Lassonde, Viktoria Kovecses and
+        /// Benoit Hudson eventually worked out:
+        /// 1. Write a HelloWorld.cs script that uses Python.Runtime to access
+        ///     some C# data from python: C# calls python, which calls C#.
+        /// 2. Execute the script (e.g. make it a MenuItem and click it).
+        /// 3. Touch HelloWorld.cs on disk, forcing Unity to recompile scripts.
+        /// 4. Wait several seconds for Unity to be done recompiling and
+        ///     reloading the C# domain.
+        /// 5. Make python run the gc (e.g. by calling gc.collect()).
+        ///
+        /// The reason:
+        /// A. In step 2, Python.Runtime registers a bunch of new types with
+        ///     their tp_traverse slot pointing to managed code, and allocates
+        ///     some objects of those types.
+        /// B. In step 4, Unity unloads the C# domain. That frees the managed
+        ///     code. But at the time of the crash investigation, pythonnet
+        ///     leaked the python side of the objects allocated in step 1.
+        /// C. In step 5, python sees some pythonnet objects in its gc list of
+        ///     potentially-leaked objects. It calls tp_traverse on those objects.
+        ///     But tp_traverse was freed in step 3 => CRASH.
+        ///
+        /// This test distills what's going on without needing Unity around (we'd see
+        /// similar behaviour if we were using pythonnet on a .NET web server that did
+        /// a hot reload).
+        /// </summary>
+        [Test]
+        [Ignore("Test crashes")]
+        public static void DomainReloadAndGC()
+        {
+            // We're set up to run in the directory that includes the bin directory.
+            System.IO.Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+
+            Assembly pythonRunner1 = BuildAssembly("test1");
+            RunAssemblyAndUnload(pythonRunner1, "test1");
+
+            // This caused a crash because objects allocated in pythonRunner1
+            // still existed in memory, but the code to do python GC on those
+            // objects is gone.
+            Assembly pythonRunner2 = BuildAssembly("test2");
+            RunAssemblyAndUnload(pythonRunner2, "test2");
+        }
+
+        //
+        // The code we'll test. All that really matters is
+        //    using GIL { Python.Exec(pyScript); }
+        // but the rest is useful for debugging.
+        //
+        // What matters in the python code is gc.collect and clr.AddReference.
+        //
+        const string TestCode = @"
+            using Python.Runtime;
+            using System;
+            class PythonRunner {
+                public static void RunPython() {
+                    AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+                    string name = AppDomain.CurrentDomain.FriendlyName;
+                    Console.WriteLine($""[{name} in .NET] In PythonRunner.RunPython"");
+                    using (Py.GIL()) {
+                        try {
+                            var pyScript = ""import clr\n""
+                                + $""print('[{name} in python] imported clr')\n""
+                                + ""clr.AddReference('System')\n""
+                                + $""print('[{name} in python] allocated a clr object')\n""
+                                + ""import gc\n""
+                                + ""gc.collect()\n""
+                                + $""print('[{name} in python] collected garbage')\n"";
+                            PythonEngine.Exec(pyScript);
+                        } catch(Exception e) {
+                            Console.WriteLine($""[{name} in .NET] Caught exception: {e}"");
+                        }
+                    }
+                }
+                static void OnDomainUnload(object sender, EventArgs e) {
+                    System.Console.WriteLine(string.Format($""[{AppDomain.CurrentDomain.FriendlyName} in .NET] unloading""));
+                }
+            }";
+
+
+        /// <summary>
+        /// Build an assembly out of the source code above.
+        /// 
+        /// This creates a file <paramref name="assemblyName"/>.dll in order
+        /// to support the statement "proxy.theAssembly = assembly" below.
+        /// That statement needs a file, can't run via memory.
+        /// </summary>
+        static Assembly BuildAssembly(string assemblyName)
+        {
+            var provider = CodeDomProvider.CreateProvider("CSharp");
+
+            var compilerparams = new CompilerParameters();
+            compilerparams.ReferencedAssemblies.Add("Python.Runtime.dll");
+            compilerparams.GenerateExecutable = false;
+            compilerparams.GenerateInMemory = false;
+            compilerparams.IncludeDebugInformation = false;
+            compilerparams.OutputAssembly = assemblyName;
+
+            var results = provider.CompileAssemblyFromSource(compilerparams, TestCode);
+            if (results.Errors.HasErrors)
+            {
+                var errors = new System.Text.StringBuilder("Compiler Errors:\n");
+                foreach (CompilerError error in results.Errors)
+                {
+                    errors.AppendFormat("Line {0},{1}\t: {2}\n",
+                            error.Line, error.Column, error.ErrorText);
+                }
+                throw new Exception(errors.ToString());
+            }
+            else
+            {
+                return results.CompiledAssembly;
+            }
+        }
+
+        /// <summary>
+        /// This is a magic incantation required to run code in an application
+        /// domain other than the current one.
+        /// </summary>
+        class Proxy : MarshalByRefObject
+        {
+            Assembly theAssembly = null;
+
+            public void InitAssembly(string assemblyPath)
+            {
+                theAssembly = Assembly.LoadFile(assemblyPath);
+            }
+
+            public void RunPython()
+            {
+                Console.WriteLine("[Proxy] Entering RunPython");
+
+                // Call into the new assembly. Will execute Python code
+                var pythonrunner = theAssembly.GetType("PythonRunner");
+                var runPythonMethod = pythonrunner.GetMethod("RunPython");
+                runPythonMethod.Invoke(null, new object[] { });
+
+                Console.WriteLine("[Proxy] Leaving RunPython");
+            }
+        }
+
+        /// <summary>
+        /// Create a domain, run the assembly in it (the RunPython function),
+        /// and unload the domain.
+        /// </summary>
+        static void RunAssemblyAndUnload(Assembly assembly, string assemblyName)
+        {
+            Console.WriteLine($"[Program.Main] === creating domain for assembly {assembly.FullName}");
+
+            // Create the domain. Make sure to set PrivateBinPath to a relative
+            // path from the CWD (namely, 'bin').
+            // See https://stackoverflow.com/questions/24760543/createinstanceandunwrap-in-another-domain
+            var currentDomain = AppDomain.CurrentDomain;
+            var domainsetup = new AppDomainSetup()
+            {
+                ApplicationBase = currentDomain.SetupInformation.ApplicationBase,
+                ConfigurationFile = currentDomain.SetupInformation.ConfigurationFile,
+                LoaderOptimization = LoaderOptimization.SingleDomain,
+                PrivateBinPath = "."
+            };
+            var domain = AppDomain.CreateDomain(
+                    $"My Domain {assemblyName}",
+                    currentDomain.Evidence,
+                domainsetup);
+
+            // Create a Proxy object in the new domain, where we want the
+            // assembly (and Python .NET) to reside
+            Type type = typeof(Proxy);
+            System.IO.Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+            var theProxy = (Proxy)domain.CreateInstanceAndUnwrap(
+                    type.Assembly.FullName,
+                    type.FullName);
+
+            // From now on use the Proxy to call into the new assembly
+            theProxy.InitAssembly(assemblyName);
+            theProxy.RunPython();
+
+            Console.WriteLine($"[Program.Main] Before Domain Unload on {assembly.FullName}");
+            AppDomain.Unload(domain);
+            Console.WriteLine($"[Program.Main] After Domain Unload on {assembly.FullName}");
+
+            // Validate that the assembly does not exist anymore
+            try
+            {
+                Console.WriteLine($"[Program.Main] The Proxy object is valid ({theProxy}). Unexpected domain unload behavior");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete.");
+            }
+        }
+
+        /// <summary>
+        /// Resolves the assembly. Why doesn't this just work normally?
+        /// </summary>
+        static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+        {
+            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in loadedAssemblies)
+            {
+                if (assembly.FullName == args.Name)
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -14,7 +14,7 @@ namespace Python.EmbeddingTest
         /// At the time this test was written, there was a very annoying
         /// seemingly random crash bug when integrating pythonnet into Unity.
         ///
-        /// The repro steps we that David Lassonde, Viktoria Kovecses and
+        /// The repro steps that David Lassonde, Viktoria Kovecses and
         /// Benoit Hudson eventually worked out:
         /// 1. Write a HelloWorld.cs script that uses Python.Runtime to access
         ///     some C# data from python: C# calls python, which calls C#.

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -2,6 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Reflection;
 using NUnit.Framework;
+using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
@@ -47,6 +48,9 @@ namespace Python.EmbeddingTest
 
             Assembly pythonRunner1 = BuildAssembly("test1");
             RunAssemblyAndUnload(pythonRunner1, "test1");
+
+            // Verify that python is not initialized even though we ran it.
+            Assert.That(Runtime.Runtime.Py_IsInitialized(), Is.Zero);
 
             // This caused a crash because objects allocated in pythonRunner1
             // still existed in memory, but the code to do python GC on those

--- a/src/embed_tests/TestRuntime.cs
+++ b/src/embed_tests/TestRuntime.cs
@@ -6,6 +6,25 @@ namespace Python.EmbeddingTest
 {
     public class TestRuntime
     {
+        /// <summary>
+        /// Test the cache of the information from the platform module.
+        ///
+        /// Test fails on platforms we haven't implemented yet.
+        /// </summary>
+        [Test]
+        public static void PlatformCache()
+        {
+            Runtime.Runtime.Initialize();
+
+            Assert.That(Runtime.Runtime.Machine, Is.Not.EqualTo(Runtime.Runtime.MachineType.Other));
+            Assert.That(!string.IsNullOrEmpty(Runtime.Runtime.MachineName));
+
+            Assert.That(Runtime.Runtime.OperatingSystem, Is.Not.EqualTo(Runtime.Runtime.OperatingSystemType.Other));
+            Assert.That(!string.IsNullOrEmpty(Runtime.Runtime.OperatingSystemName));
+
+            Runtime.Runtime.Shutdown();
+        }
+
         [Test]
         public static void Py_IsInitializedValue()
         {

--- a/src/embed_tests/TestTypeManager.cs
+++ b/src/embed_tests/TestTypeManager.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Python.Runtime;
+using System.Runtime.InteropServices;
+
+namespace Python.EmbeddingTest
+{
+    class TestTypeManager
+    {
+        [Test]
+        public static void TestNativeCode()
+        {
+            Runtime.Runtime.Initialize();
+
+            Assert.That(() => { var _ = TypeManager.NativeCode.Active; }, Throws.Nothing);
+            Assert.That(TypeManager.NativeCode.Active.Code.Length, Is.GreaterThan(0));
+
+            Runtime.Runtime.Shutdown();
+        }
+
+        [Test]
+        public static void TestMemoryMapping()
+        {
+            Runtime.Runtime.Initialize();
+
+            Assert.That(() => { var _ = TypeManager.CreateMemoryMapper(); }, Throws.Nothing);
+            var mapper = TypeManager.CreateMemoryMapper();
+
+            // Allocate a read-write page.
+            int len = 12;
+            var page = mapper.MapWriteable(len);
+            Assert.That(() => { Marshal.WriteInt64(page, 17); }, Throws.Nothing);
+            Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
+
+            // Mark it read-execute, now we can't write anymore (I'm not testing we can execute).
+            // We should be getting AccessViolationException, but Mono translates
+            // SIGSEGV to NullReferenceException instead, so just check for some exception.
+            mapper.SetReadExec(page, len);
+            Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
+            Assert.That(() => { Marshal.WriteInt64(page, 18); }, Throws.Exception);
+            Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
+
+            Runtime.Runtime.Shutdown();
+        }
+    }
+}

--- a/src/embed_tests/TestTypeManager.cs
+++ b/src/embed_tests/TestTypeManager.cs
@@ -32,9 +32,10 @@ namespace Python.EmbeddingTest
             Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
 
             // Mark it read-execute, now we can't write anymore.
-            // We can't actually test access protectoin under Windows,
-            // because AccessViolationException is assumed to mean we're in a
-            // corrupted state:
+            //
+            // We can't actually test access protection under Windows, because
+            // AccessViolationException is assumed to mean we're in a corrupted
+            // state:
             //   https://stackoverflow.com/questions/3469368/how-to-handle-accessviolationexception
             mapper.SetReadExec(page, len);
             Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));

--- a/src/embed_tests/TestTypeManager.cs
+++ b/src/embed_tests/TestTypeManager.cs
@@ -31,13 +31,19 @@ namespace Python.EmbeddingTest
             Assert.That(() => { Marshal.WriteInt64(page, 17); }, Throws.Nothing);
             Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
 
-            // Mark it read-execute, now we can't write anymore (I'm not testing we can execute).
-            // We should be getting AccessViolationException, but Mono translates
-            // SIGSEGV to NullReferenceException instead, so just check for some exception.
+            // Mark it read-execute, now we can't write anymore.
+            // We can't actually test access protectoin under Windows,
+            // because AccessViolationException is assumed to mean we're in a
+            // corrupted state:
+            //   https://stackoverflow.com/questions/3469368/how-to-handle-accessviolationexception
             mapper.SetReadExec(page, len);
             Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
-            Assert.That(() => { Marshal.WriteInt64(page, 18); }, Throws.Exception);
-            Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
+            if (Runtime.Runtime.OperatingSystem != Runtime.Runtime.OperatingSystemType.Windows)
+            {
+                // Mono throws NRE instead of AccessViolationException for some reason.
+                Assert.That(() => { Marshal.WriteInt64(page, 73); }, Throws.TypeOf<System.NullReferenceException>());
+                Assert.That(Marshal.ReadInt64(page), Is.EqualTo(17));
+            }
 
             Runtime.Runtime.Shutdown();
         }

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -248,24 +248,6 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// Default implementations for required Python GC support.
-        /// </summary>
-        public static int tp_traverse(IntPtr ob, IntPtr func, IntPtr args)
-        {
-            return 0;
-        }
-
-        public static int tp_clear(IntPtr ob)
-        {
-            return 0;
-        }
-
-        public static int tp_is_gc(IntPtr type)
-        {
-            return 1;
-        }
-
-        /// <summary>
         /// Standard dealloc implementation for instances of reflected types.
         /// </summary>
         public static void tp_dealloc(IntPtr ob)

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -82,27 +82,6 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// Required Python GC support.
-        /// </summary>
-        public static int tp_traverse(IntPtr ob, IntPtr func, IntPtr args)
-        {
-            return 0;
-        }
-
-
-        public static int tp_clear(IntPtr ob)
-        {
-            return 0;
-        }
-
-
-        public static int tp_is_gc(IntPtr type)
-        {
-            return 1;
-        }
-
-
-        /// <summary>
         /// Default dealloc implementation.
         /// </summary>
         public static void tp_dealloc(IntPtr ob)

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -220,7 +220,15 @@ namespace Python.Runtime
                 {
                     locals.Dispose();
                 }
+
+                // Make sure we clean up properly on app domain unload.
+                AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
             }
+        }
+
+        static void OnDomainUnload(object _, EventArgs __)
+        {
+            Shutdown();
         }
 
         /// <summary>
@@ -303,6 +311,8 @@ namespace Python.Runtime
                 _pythonPath = IntPtr.Zero;
 
                 Runtime.Shutdown();
+
+                AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
                 initialized = false;
             }
         }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -231,10 +231,17 @@ namespace Python.Runtime
             Other
         };
 
+        /// <summary>
+	/// Map lower-case version of the python machine name to the processor
+	/// type.  There are aliases, e.g. x86_64 and amd64 are two names for
+	/// the same thing.  Make sure to lower-case the search string, because
+	/// capitalization can differ.
+        /// </summary>
         static readonly Dictionary<string, MachineType> MachineTypeMapping = new Dictionary<string, MachineType>()
         {
             { "i386", MachineType.i386 },
             { "x86_64", MachineType.x86_64 },
+            { "amd64", MachineType.x86_64 },
         };
 
         /// <summary>
@@ -444,7 +451,7 @@ namespace Python.Runtime
             OperatingSystem = OSType;
 
             MachineType MType;
-            if (!MachineTypeMapping.TryGetValue(MachineName, out MType))
+            if (!MachineTypeMapping.TryGetValue(MachineName.ToLower(), out MType))
             {
                 MType = MachineType.Other;
             }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -232,10 +232,10 @@ namespace Python.Runtime
         };
 
         /// <summary>
-	/// Map lower-case version of the python machine name to the processor
-	/// type.  There are aliases, e.g. x86_64 and amd64 are two names for
-	/// the same thing.  Make sure to lower-case the search string, because
-	/// capitalization can differ.
+        /// Map lower-case version of the python machine name to the processor
+        /// type. There are aliases, e.g. x86_64 and amd64 are two names for
+        /// the same thing. Make sure to lower-case the search string, because
+        /// capitalization can differ.
         /// </summary>
         static readonly Dictionary<string, MachineType> MachineTypeMapping = new Dictionary<string, MachineType>()
         {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using System.Collections.Generic;
 
 namespace Python.Runtime
 {
@@ -195,6 +196,57 @@ namespace Python.Runtime
         // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         internal static bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
+        /// <summary>
+        /// Operating system type as reported by Python.
+        /// </summary>
+        public enum OperatingSystemType
+        {
+            Windows,
+            Darwin,
+            Linux,
+            Other
+        }
+
+        static readonly Dictionary<string, OperatingSystemType> OperatingSystemTypeMapping = new Dictionary<string, OperatingSystemType>()
+        {
+            { "Windows", OperatingSystemType.Windows },
+            { "Darwin", OperatingSystemType.Darwin },
+            { "Linux", OperatingSystemType.Linux },
+        };
+
+        /// <summary>
+        /// Gets the operating system as reported by python's platform.system().
+        /// </summary>
+        public static OperatingSystemType OperatingSystem { get; private set; }
+
+        /// <summary>
+        /// Gets the operating system as reported by python's platform.system().
+        /// </summary>
+        public static string OperatingSystemName { get; private set; }
+
+        public enum MachineType
+        {
+            i386,
+            x86_64,
+            Other
+        };
+
+        static readonly Dictionary<string, MachineType> MachineTypeMapping = new Dictionary<string, MachineType>()
+        {
+            { "i386", MachineType.i386 },
+            { "x86_64", MachineType.x86_64 },
+        };
+
+        /// <summary>
+        /// Gets the machine architecture as reported by python's platform.machine().
+        /// </summary>
+        public static MachineType Machine { get; private set; }/* set in Initialize using python's platform.machine */
+
+        /// <summary>
+        /// Gets the machine architecture as reported by python's platform.machine().
+        /// </summary>
+        public static string MachineName { get; private set; }
+
         internal static bool IsPython2 = pyversionnumber < 30;
         internal static bool IsPython3 = pyversionnumber >= 30;
 
@@ -331,6 +383,10 @@ namespace Python.Runtime
                 NativeMethods.FreeLibrary(dllLocal);
             }
 #endif
+            // Initialize data about the platform we're running on. We need
+            // this for the type manager and potentially other details. Must
+            // happen after caching the python types, above.
+            InitializePlatformData();
 
             // Initialize modules that depend on the runtime class.
             AssemblyManager.Initialize();
@@ -346,6 +402,53 @@ namespace Python.Runtime
             PyList_Append(path, item);
             XDecref(item);
             AssemblyManager.UpdatePath();
+        }
+
+        /// <summary>
+        /// Initializes the data about platforms.
+        ///
+        /// This must be the last step when initializing the runtime:
+        /// GetManagedString needs to have the cached values for types.
+        /// But it must run before initializing anything outside the runtime
+        /// because those rely on the platform data.
+        /// </summary>
+        private static void InitializePlatformData()
+        {
+            IntPtr op;
+            IntPtr fn;
+            IntPtr platformModule = PyImport_ImportModule("platform");
+            IntPtr emptyTuple = PyTuple_New(0);
+
+            fn = PyObject_GetAttrString(platformModule, "system");
+            op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
+            OperatingSystemName = GetManagedString(op);
+            XDecref(op);
+            XDecref(fn);
+
+            fn = PyObject_GetAttrString(platformModule, "machine");
+            op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
+            MachineName = GetManagedString(op);
+            XDecref(op);
+            XDecref(fn);
+
+            XDecref(emptyTuple);
+            XDecref(platformModule);
+
+            // Now convert the strings into enum values so we can do switch
+            // statements rather than constant parsing.
+            OperatingSystemType OSType;
+            if (!OperatingSystemTypeMapping.TryGetValue(OperatingSystemName, out OSType))
+            {
+                OSType = OperatingSystemType.Other;
+            }
+            OperatingSystem = OSType;
+
+            MachineType MType;
+            if (!MachineTypeMapping.TryGetValue(MachineName, out MType))
+            {
+                MType = MachineType.Other;
+            }
+            Machine = MType;
         }
 
         internal static void Shutdown()

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -454,7 +454,10 @@ namespace Python.Runtime
         /// </summary>
         internal static void InitializeSlots(IntPtr type, Type impl)
         {
-            var seen = new Hashtable(8);
+            // We work from the most-derived class up; make sure to get
+            // the most-derived slot and not to override it with a base
+            // class's slot.
+            var seen = new HashSet<string>();
             Type offsetType = typeof(TypeOffset);
 
             while (impl != null)
@@ -473,7 +476,7 @@ namespace Python.Runtime
                         continue;
                     }
 
-                    if (seen[name] != null)
+                    if (seen.Contains(name))
                     {
                         continue;
                     }
@@ -484,7 +487,7 @@ namespace Python.Runtime
                     IntPtr slot = Interop.GetThunk(method);
                     Marshal.WriteIntPtr(type, offset, slot);
 
-                    seen[name] = 1;
+                    seen.Add(name);
                 }
 
                 impl = impl.BaseType;

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -487,12 +487,12 @@ namespace Python.Runtime
             public byte[] Code { get; private set; }
 
             /// <summary>
-            /// The offset for the "return 0" function. Usually zero.
+            /// Where does the "return 0" function start?
             /// </summary>
             public int Return0 { get; private set; }
 
             /// <summary>
-            /// The offset for the "return 1" function. Usually one.
+            /// Where does the "return 1" function start?
             /// </summary>
             public int Return1 { get; private set; }
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -507,7 +507,7 @@ namespace Python.Runtime
                         case Runtime.MachineType.x86_64:
                             return X86_64;
                         default:
-                            throw new NotImplementedException($"No support for ${Runtime.MachineName}");
+                            throw new NotImplementedException($"No support for {Runtime.MachineName}");
                     }
                 }
             }

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -447,6 +447,222 @@ namespace Python.Runtime
         }
 
 
+        #region Native Page
+        /// <summary>
+        /// Initialized by InitializeNativeCodePage.
+        ///
+        /// This points to a page of memory allocated using mmap or VirtualAlloc
+        /// (depending on the system), and marked read and execute (not write).
+        /// Very much on purpose, the page is *not* released on a shutdown and
+        /// is instead leaked. See the TestDomainReload test case.
+        ///
+        /// The contents of the page are two native functions: one that returns 0,
+        /// one that returns 1.
+        ///
+        /// If python didn't keep its gc list through a Py_Finalize we could remove
+        /// this entire section.
+        /// </summary>
+        internal static IntPtr NativeCodePage = IntPtr.Zero;
+
+        /// <summary>
+        /// Structure to describe native code.
+        ///
+        /// Use NativeCode.Active to get the native code for the current platform.
+        ///
+        /// Generate the code by creating the following C code:
+        /// <code>
+        /// int Return0() { return 0; }
+        /// int Return1() { return 1; }
+        /// </code>
+        /// Then compiling on the target platform, e.g. with gcc or clang:
+        /// <code>cc -c -fomit-frame-pointer -O2 foo.c</code>
+        /// And then analyzing the resulting functions with a hex editor, e.g.:
+        /// <code>objdump -disassemble foo.o</code>
+        /// </summary>
+        internal class NativeCode
+        {
+            /// <summary>
+            /// The code, as a string of bytes.
+            /// </summary>
+            public byte[] Code { get; private set; }
+
+            /// <summary>
+            /// The offset for the "return 0" function. Usually zero.
+            /// </summary>
+            public int Return0 { get; private set; }
+
+            /// <summary>
+            /// The offset for the "return 1" function. Usually one.
+            /// </summary>
+            public int Return1 { get; private set; }
+
+            public static NativeCode Active
+            {
+                get
+                {
+                    switch(Runtime.Machine)
+                    {
+                        case Runtime.MachineType.i386:
+                            return I386;
+                        case Runtime.MachineType.x86_64:
+                            return X86_64;
+                        default:
+                            throw new NotImplementedException($"No support for ${Runtime.MachineName}");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Code for x86_64. See the class comment for how it was generated.
+            /// </summary>
+            public static readonly NativeCode X86_64 = new NativeCode()
+            {
+                Return0 = 0x10,
+                Return1 = 0,
+                Code = new byte[]
+                {
+                    // First Return1:
+                    0xb8, 0x01, 0x00, 0x00, 0x00, // movl $1, %eax
+                    0xc3, // ret
+
+                    // Now some padding so that Return0 can be 16-byte-aligned.
+                    // I put Return1 first so there's not as much padding to type in.
+                    0x66, 0x2e, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00, // nop
+
+                    // Now Return0.
+                    0x31, 0xc0, // xorl %eax, %eax
+                    0xc3, // ret
+                }
+            };
+
+            /// <summary>
+            /// Code for X86.
+            ///
+            /// It's bitwise identical to X86_64, so we just point to it.
+            /// <see cref="NativeCode.X86_64"/>
+            /// </summary>
+            public static readonly NativeCode I386 = X86_64;
+        }
+
+        /// <summary>
+        /// Platform-dependent mmap and mprotect.
+        /// </summary>
+        internal interface IMemoryMapper
+        {
+            /// <summary>
+            /// Map at least numBytes of memory. Mark the page read-write (but not exec).
+            /// </summary>
+            IntPtr MapWriteable(int numBytes);
+
+            /// <summary>
+            /// Sets the mapped memory to be read-exec (but not write).
+            /// </summary>
+            void SetReadExec(IntPtr mappedMemory, int numBytes);
+        }
+
+        class WindowsMemoryMapper : IMemoryMapper
+        {
+            const UInt32 MEM_COMMIT = 0x1000;
+            const UInt32 MEM_RESERVE = 0x2000;
+            const UInt32 PAGE_READWRITE = 0x04;
+            const UInt32 PAGE_EXECUTE_READ = 0x20;
+
+            [DllImport("kernel32.dll")]
+            static extern IntPtr VirtualAlloc(IntPtr lpAddress, IntPtr dwSize, UInt32 flAllocationType, UInt32 flProtect);
+
+            [DllImport("kernel32.dll")]
+            static extern bool VirtualProtect(IntPtr lpAddress, IntPtr dwSize, UInt32 flNewProtect, out UInt32 lpflOldProtect);
+
+            public IntPtr MapWriteable(int numBytes)
+            {
+                return VirtualAlloc(IntPtr.Zero, new IntPtr(numBytes),
+                                    MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+            }
+
+            public void SetReadExec(IntPtr mappedMemory, int numBytes)
+            {
+                UInt32 _;
+                VirtualProtect(mappedMemory, new IntPtr(numBytes), PAGE_EXECUTE_READ, out _);
+            }
+        }
+
+        class UnixMemoryMapper : IMemoryMapper
+        {
+            const int PROT_READ = 0x1;
+            const int PROT_WRITE = 0x2;
+            const int PROT_EXEC = 0x4;
+
+            int MAP_ANONYMOUS
+            {
+                get
+                {
+                    switch (Runtime.OperatingSystem)
+                    {
+                        case Runtime.OperatingSystemType.Darwin:
+                            return 0x1000;
+                        case Runtime.OperatingSystemType.Linux:
+                            return 0x20;
+                        default:
+                            throw new NotImplementedException($"mmap is not supported on {Runtime.OperatingSystemName}");
+                    }
+                }
+            }
+
+            [DllImport("__Internal")]
+            static extern IntPtr mmap(IntPtr addr, IntPtr len, int prot, int flags, int fd, IntPtr offset);
+
+            [DllImport("__Internal")]
+            static extern int mprotect(IntPtr addr, IntPtr len, int prot);
+
+            public IntPtr MapWriteable(int numBytes)
+            {
+                return mmap(IntPtr.Zero, new IntPtr(numBytes), PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, IntPtr.Zero);
+            }
+
+            public void SetReadExec(IntPtr mappedMemory, int numBytes)
+            {
+                mprotect(mappedMemory, new IntPtr(numBytes), PROT_READ | PROT_EXEC);
+            }
+        }
+
+        internal static IMemoryMapper CreateMemoryMapper()
+        {
+            switch (Runtime.OperatingSystem)
+            {
+                case Runtime.OperatingSystemType.Darwin:
+                case Runtime.OperatingSystemType.Linux:
+                    return new UnixMemoryMapper();
+                case Runtime.OperatingSystemType.Windows:
+                    return new WindowsMemoryMapper();
+                default:
+                    throw new NotImplementedException($"No support for {Runtime.OperatingSystemName}");
+            }
+        }
+
+        /// <summary>
+        /// Initializes the native code page.
+        ///
+        /// Safe to call if we already initialized (this function is idempotent).
+        /// <see cref="NativeCodePage"/>
+        /// </summary>
+        internal static void InitializeNativeCodePage()
+        {
+            // Do nothing if we already initialized.
+            if (NativeCodePage != IntPtr.Zero)
+            {
+                return;
+            }
+
+            // Allocate the page, write the native code into it, then set it
+            // to be executable.
+            IMemoryMapper mapper = CreateMemoryMapper();
+            int codeLength = NativeCode.Active.Code.Length;
+            NativeCodePage = mapper.MapWriteable(codeLength);
+            Marshal.Copy(NativeCode.Active.Code, 0, NativeCodePage, codeLength);
+            mapper.SetReadExec(NativeCodePage, codeLength);
+        }
+#endregion
+
         /// <summary>
         /// Given a newly allocated Python type object and a managed Type that
         /// provides the implementation for the type, connect the type slots of
@@ -458,7 +674,6 @@ namespace Python.Runtime
             // the most-derived slot and not to override it with a base
             // class's slot.
             var seen = new HashSet<string>();
-            Type offsetType = typeof(TypeOffset);
 
             while (impl != null)
             {
@@ -481,19 +696,47 @@ namespace Python.Runtime
                         continue;
                     }
 
-                    FieldInfo fi = offsetType.GetField(name);
-                    var offset = (int)fi.GetValue(offsetType);
-
-                    IntPtr slot = Interop.GetThunk(method);
-                    Marshal.WriteIntPtr(type, offset, slot);
+                    InitializeSlot(type, Interop.GetThunk(method), name);
 
                     seen.Add(name);
                 }
 
                 impl = impl.BaseType;
             }
+
+            // See the TestDomainReload test: there was a crash related to
+            // the gc-related slots. They always return 0 or 1 because we don't
+            // really support gc:
+            //   tp_traverse (returns 0)
+            //   tp_clear    (returns 0)
+            //   tp_is_gc    (returns 1)
+            // We can't do without: python really wants those slots to exist.
+            // We can't implement those in C# because the application domain
+            // can be shut down and the memory released.
+            InitializeNativeCodePage();
+            InitializeSlot(type, NativeCodePage + NativeCode.Active.Return0, "tp_traverse");
+            InitializeSlot(type, NativeCodePage + NativeCode.Active.Return0, "tp_clear");
+            InitializeSlot(type, NativeCodePage + NativeCode.Active.Return1, "tp_is_gc");
         }
 
+        /// <summary>
+        /// Helper for InitializeSlots.
+        ///
+        /// Initializes one slot to point to a function pointer.
+        /// The function pointer might be a thunk for C#, or it may be
+        /// an address in the NativeCodePage.
+        /// </summary>
+        /// <param name="type">Type being initialized.</param>
+        /// <param name="slot">Function pointer.</param>
+        /// <param name="name">Name of the method.</param>
+        static void InitializeSlot(IntPtr type, IntPtr slot, string name)
+        {
+            Type typeOffset = typeof(TypeOffset);
+            FieldInfo fi = typeOffset.GetField(name);
+            var offset = (int)fi.GetValue(typeOffset);
+
+            Marshal.WriteIntPtr(type, offset, slot);
+        }
 
         /// <summary>
         /// Given a newly allocated Python type object and a managed Type that

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -592,6 +592,7 @@ namespace Python.Runtime
             const int PROT_WRITE = 0x2;
             const int PROT_EXEC = 0x4;
 
+            const int MAP_PRIVATE = 0x2;
             int MAP_ANONYMOUS
             {
                 get
@@ -616,7 +617,9 @@ namespace Python.Runtime
 
             public IntPtr MapWriteable(int numBytes)
             {
-                return mmap(IntPtr.Zero, new IntPtr(numBytes), PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, IntPtr.Zero);
+                // MAP_PRIVATE must be set on linux, even though MAP_ANON implies it.
+                // It doesn't hurt on darwin, so just do it.
+                return mmap(IntPtr.Zero, new IntPtr(numBytes), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, IntPtr.Zero);
             }
 
             public void SetReadExec(IntPtr mappedMemory, int numBytes)

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -447,7 +447,7 @@ namespace Python.Runtime
         }
 
 
-        #region Native Page
+        #region Native Code Page
         /// <summary>
         /// Initialized by InitializeNativeCodePage.
         ///


### PR DESCRIPTION
Note: this is going into a copy of the pythonnet master, not to the Unity-technologies master which has lots of bumbling about from our earlier phases.

This patch implements a fix to two crashes when integrating pythonnet into Unity3d.

1. On domain reload, shut down pythonnet. Otherwise there'll be a bunch of objects in python that point to functions implemented in C# code that isn't there anymore. In particular, the trick of replacing the import function means that on an import statement in the second domain, python is calling into deallocated memory.

2. Implement the garbage collection support in native code in memory that is not deallocated. Python's garbage collector keeps pointers to python objects that were allocated in the first domain and leaked on Py_Finalize. Python doesn't clear that list in Py_Initialize. This means it will try to collect these objects in the second domain. This led to a crash because garbage collection support for the python objects was implemented in C#, so on the first gc in the second domain, python was calling into deallocated memory.

3. Use python's platform module to determine the platform at runtime so we know what native code to build and how to allocate an executable page. I'm preferring to check at runtime rather than at compile time so we can get away from shipping a .net DLL per configuration.

4. Unit tests for domain reload, the platform module, and for allocating a page of memory.

Support is currently windows and mac, i386 and x86_64. Linux might work too, but I haven't tested yet. Unit tests will fail with a descriptive message on other platforms.