### PR TITLE
Ut3590/pythonnet dll linux

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -151,7 +151,14 @@ namespace Python.Runtime
         {
             if (!libraryLoaded)
             {
-                var _loader = Python.Runtime.Platform.LibraryLoader.Get(Runtime.OperatingSystem);
+#if MONO_OSX
+                var os = Python.Runtime.Platform.OperatingSystemType.Darwin;
+#elif MONO_LINUX
+                var os = Python.Runtime.Platform.OperatingSystemType.Linux;
+#else
+                var os = Python.Runtime.Platform.OperatingSystemType.Windows;
+#endif
+                var _loader = Python.Runtime.Platform.LibraryLoader.Get(os);
                 _loader.Load(Runtime.pythonlib, Runtime.dllDirectory);
                 libraryLoaded = true;
             }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -101,7 +101,7 @@ namespace Python.Runtime
         internal const string dllDirectory = "Library/conda/lib/";
         internal const string pythonlib = "python3.7m";
 #elif MONO_MAC
-        internal const string dllDirectory = "/Library/PythonInstall/lib/";
+        internal const string dllDirectory = "Library/PythonInstall/lib/";
         internal const string pythonlib = "python3.7m";
 #else //windows
         internal const string dllDirectory = "Library/PythonInstall/";
@@ -378,6 +378,12 @@ namespace Python.Runtime
             IntPtr platformModule = PyImport_ImportModule("platform");
             IntPtr emptyTuple = PyTuple_New(0);
 
+            fn = PyObject_GetAttrString(platformModule, "system");
+            op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
+            string operatingSystemName = GetManagedString(op);
+            XDecref(op);
+            XDecref(fn);
+
             fn = PyObject_GetAttrString(platformModule, "machine");
             op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
             string machineName = GetManagedString(op);
@@ -389,6 +395,12 @@ namespace Python.Runtime
 
             // Now convert the strings into enum values so we can do switch
             // statements rather than constant parsing.
+            OperatingSystemType OSType;
+            if (!OperatingSystemTypeMapping.TryGetValue(operatingSystemName, out OSType))
+            {
+                OSType = OperatingSystemType.Other;
+            }
+            OperatingSystem = OSType;
 
             MachineType MType;
             if (!MachineTypeMapping.TryGetValue(machineName.ToLower(), out MType))

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -347,10 +347,10 @@ namespace Python.Runtime
             }
 
 #if MONO_LINUX
-            string[] dyLibPaths = IO.Directory.GetFiles(dllDirectory, "*.so");
+            string[] dyLibPaths = System.IO.Directory.GetFiles(dllDirectory, "*.so");
             foreach (string dyLibPath in dyLibPaths)
             {
-                string dyLibName = IO.Path.GetFileNameWithoutExtension(dyLibPath);
+                string dyLibName = System.IO.Path.GetFileNameWithoutExtension(dyLibPath);
                 if (! dyLibName.Contains("python"))
                 {
                     // remove the first three characters, "lib"

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -318,9 +318,16 @@ namespace Python.Runtime
             InitializePlatformData();
 
             IntPtr dllLocal = IntPtr.Zero;
-            var loader = LibraryLoader.Get(OperatingSystem);
 
-            if (!(OperatingSystem == OperatingSystemType.Windows))
+#if MONO_OSX
+                var os = Python.Runtime.Platform.OperatingSystemType.Darwin;
+#elif MONO_LINUX
+                var os = Python.Runtime.Platform.OperatingSystemType.Linux;
+#else
+                var os = Python.Runtime.Platform.OperatingSystemType.Windows;
+#endif
+            var loader = LibraryLoader.Get(os);
+            if (!(os == OperatingSystemType.Windows))
             {
             if (_PythonDll != "__Internal")
             {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -100,9 +100,6 @@ namespace Python.Runtime
 #if MONO_LINUX || MONO_MAC
         internal const string dllDirectory = "Library/PythonInstall/lib/";
         internal const string pythonlib = "python3.7m";
-// #elif MONO_MAC
-//         internal const string dllDirectory = "Library/PythonInstall/lib/";
-//         internal const string pythonlib = "python3.7m";
 #else //windows
         internal const string dllDirectory = "Library/PythonInstall/";
         internal const string pythonlib = "python37";


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Preprocessor directives to load platform relevant dll before `Runtime.OperatingSystem` is defined.`
Initialize `Runtime.OperatingSystem`
On Linux, load dynamic libraries in memory when initalizing Runtime
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
