### PR TITLE
Modernize the import hook

### DIFF
--- a/src/domain_tests/TestRunner.cs
+++ b/src/domain_tests/TestRunner.cs
@@ -1094,6 +1094,29 @@ def after_reload():
     
                     ",
             },
+            new TestCase
+            {
+                // The C# code for this test doesn't matter; we're testing
+                // that the import hook behaves properly after a domain reload
+                Name = "import_after_reload",
+                DotNetBefore = "",
+                DotNetAfter = "",
+                PythonCode = @"
+import sys
+
+def before_reload():
+    import clr
+    import System
+
+
+def after_reload():
+    assert 'System' in sys.modules
+    assert 'clr' in sys.modules
+    import clr
+    import System
+    
+                    ",
+            },
         };
 
         /// <summary>

--- a/src/domain_tests/test_domain_reload.py
+++ b/src/domain_tests/test_domain_reload.py
@@ -98,3 +98,7 @@ def test_in_to_ref_param():
 @pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
 def test_nested_type():
     _run_test("nested_type")
+
+@pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
+def test_import_after_reload():
+    _run_test("import_after_reload")

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -76,7 +76,7 @@ namespace Python.Runtime
             {
                 message = "readonly attribute";
             }
-            Exceptions.SetError(Exceptions.TypeError, message);
+            Exceptions.SetError(Exceptions.AttributeError, message);
             return -1;
         }
 

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -19,6 +19,12 @@ namespace Python.Runtime
         internal string moduleName;
         internal IntPtr dict;
         protected string _namespace;
+        private IntPtr __all__ = IntPtr.Zero;
+
+        // Attributes to be set on the module according to PEP302 and 451
+        // by the import machinery.
+        static readonly HashSet<string> settableAttributes = 
+            new HashSet<string> {"__spec__", "__file__", "__name__", "__path__", "__loader__", "__package__"};
 
         public ModuleObject(string name)
         {
@@ -44,6 +50,7 @@ namespace Python.Runtime
             }
 
             dict = Runtime.PyDict_New();
+            __all__ = Runtime.PyList_New(0);
             IntPtr pyname = Runtime.PyString_FromString(moduleName);
             IntPtr pyfilename = Runtime.PyString_FromString(filename);
             IntPtr pydocstring = Runtime.PyString_FromString(docstring);
@@ -183,7 +190,23 @@ namespace Python.Runtime
                 {
                     continue;
                 }
-                GetAttribute(name, true);
+
+                if(GetAttribute(name, true) != null)
+                {
+                    // if it's a valid attribute, add it to __all__
+                    var pyname = Runtime.PyString_FromString(name);
+                    try
+                    {
+                        if (Runtime.PyList_Append(new BorrowedReference(__all__), pyname) != 0)
+                        {
+                            throw new PythonException();
+                        }
+                    }
+                    finally
+                    {
+                        Runtime.XDecref(pyname);
+                    }
+                }
             }
         }
 
@@ -265,6 +288,13 @@ namespace Python.Runtime
                 return self.dict;
             }
 
+            if (name == "__all__")
+            {
+                self.LoadNames();
+                Runtime.XIncref(self.__all__);
+                return self.__all__;
+            }
+
             ManagedType attr = null;
 
             try
@@ -328,6 +358,25 @@ namespace Python.Runtime
             }
             self.cache.Clear();
             return 0;
+        }
+
+        /// <summary>
+        /// Override the setattr implementation.
+        /// This is needed because the import mechanics need
+        /// to set a few attributes
+        /// </summary>
+        [ForbidPythonThreads]
+        public new static int tp_setattro(IntPtr ob, IntPtr key, IntPtr val)
+        {
+            var managedKey = Runtime.GetManagedString(key);
+            if ((settableAttributes.Contains(managedKey)) || 
+                (ManagedType.GetManagedObject(val)?.GetType() == typeof(ModuleObject)) )
+            {
+                var self = (ModuleObject)ManagedType.GetManagedObject(ob);
+                return Runtime.PyDict_SetItem(self.dict, key, val);
+            }
+
+            return ExtensionType.tp_setattro(ob, key, val);
         }
 
         protected override void OnSave(InterDomainContext context)
@@ -489,7 +538,8 @@ namespace Python.Runtime
             {
                 throw new FileNotFoundException($"Unable to find assembly '{name}'.");
             }
-
+            // Classes that are not in a namespace needs an extra nudge to be found.
+            ImportHook.UpdateCLRModuleDict();
             return assembly;
         }
 
@@ -541,6 +591,29 @@ namespace Python.Runtime
         public static int _AtExit()
         {
             return Runtime.AtExit();
+        }
+
+
+        /// <summary>
+        /// Note: This should *not* be called directly.
+        /// The function that get/import a CLR assembly as a python module.
+        /// This function should only be called by the import machinery as seen
+        /// in importhook.cs
+        /// </summary>
+        /// <param name="spec">A ModuleSpec Python object</param>
+        /// <returns>A new reference to the imported module, as a PyObject.</returns>
+        [ModuleFunction]
+        [ForbidPythonThreads]
+        public static PyObject _LoadClrModule(PyObject spec)
+        {
+            ModuleObject mod = null;
+            using (var modname = spec.GetAttr("name"))
+            {
+                mod = ImportHook.__import__(modname.ToString());
+            }
+            // We can't return directly a ModuleObject, because the tpHandle is
+            // not set, but we can return a PyObject.
+            return new PyObject(mod.pyHandle);
         }
     }
 }

--- a/src/runtime/native/TypeOffset.cs
+++ b/src/runtime/native/TypeOffset.cs
@@ -157,6 +157,7 @@ namespace Python.Runtime
                 "getPreload",
                 "Initialize",
                 "ListAssemblies",
+                "_LoadClrModule",
                 "Release",
                 "Reset",
                 "set_SuppressDocs",


### PR DESCRIPTION
Implement a meta path loader instead

Add the loaded namespaces tracking

Fix a bug where clr wasn't in sys.modules after reload

Further refinements to setattr logic on ModuleObjects

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
